### PR TITLE
Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,13 @@ after_script:
 env:
   global:
     secure: JsKJJu1GFCyNFuU3fsQgn+0J6o6tBT6cC1xlD/qrd1adL8UsFs2sWl0pKzKbbEat28S5nZkyqGyiK1b5s6KUVohwY78pSO67t/4HJxIOqoD8Ut9vKlW+12bdBC7rMF6LrLMRABWfiu9t5CryGl8ydR51RcTBW7pzHe3Mqxmbzq5ZI1oa5pAPESJz7CNpifzMhKmvUfu7uRIwAeD1TMq7SYF6cz7t05I2CtnwL5EqWRluwwJaZOGF2dNNm6+mk6G/3lyUvKz513is4yZb0psbZ6fKbxbnahWiZnm6mcChtHWCRt5JAJvShePOudHFovaKsh+YGYZb+IPvj/62zKxWsLdngr+zRIiJ2AB7EekU4K6OqnzWqwKSS/znaN2YADoFQAmreJh3f/LREADH8tDi3S5pX9oyCk5YbF/5dg1YoPVv5gJBm+/MUXaTeLKLWcoNuHhTRhmtmY8S7acLz3PPVKTlKhcoTkhEzNpZS/gVkoId62xJ4ehVDA3bJ4dSJ9M0bSJqKioVXgl/b4DgYrOgvZQ1r7/D8f4Zi4yQTEM0ZMCQ2dwLWglUqDiIRa1kKPfCWjMq7XfsMCN3nnMPfj+bvbFqBBUXzoIpJi1jRYA33NTmOc6jkO3Np3byokOci4bk2BOjQsRo7LCE0PKvHcs+IC8DHvSRaerH1tZLLwvxtfs=
+before_deploy:
+  - yarn build
+deploy:
+  provider: pages
+  on:
+    branch: master
+  allow_empty_commit: true
+  keep_history: true
+  skip_cleanup: true
+  local_dir: dist/

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "test": "jest && cat ./coverage/lcov.info | yarn report",
     "report": "if [ \"${CI}\" ]; then (coveralls) fi"
   },
-  "dependencies": {},
+  "dependencies": {
+    "seedrandom": "^2.4.3"
+  },
   "devDependencies": {
     "@types/jest": "^22.1.1",
+    "@types/seedrandom": "^2.4.27",
     "commitizen": "^2.9.6",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",

--- a/source/index.html
+++ b/source/index.html
@@ -11,9 +11,11 @@
 <body>
   <main id="main">
     <canvas id="canvas"></canvas>
+    <!--
     <div>
       <button id="play-stop" aria-label="play">▶</button>
     </div>
+    -->
   </main>
   <script src="./script.ts"></script>
 </body>

--- a/source/lib/math/index.ts
+++ b/source/lib/math/index.ts
@@ -1,2 +1,5 @@
-export const { atan2, cos, hypot, PI: π, random, sin, sqrt } = Math;
+import seedRandom from 'seedrandom';
+
+export const random = seedRandom('fart.ts');
+export const { atan2, cos, hypot, PI: π, sin, sqrt } = Math;
 export const ππ = π * 2;

--- a/source/script.ts
+++ b/source/script.ts
@@ -7,9 +7,9 @@ import Particle from './lib/physics/particle';
 const { add, fromPolar, lerp, scale, zero } = Vec2;
 const { cancelAnimationFrame: cAF, requestAnimationFrame: rAF } = window;
 
-const playStopButton = document.getElementById('play-stop') as HTMLButtonElement;
-const playLabel = '▶';
-const stopLabel = '■';
+// const playStopButton = document.getElementById('play-stop') as HTMLButtonElement;
+// const playLabel = '▶';
+// const stopLabel = '■';
 
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
 const canvasContext = canvas.getContext('2d') as CanvasRenderingContext2D;
@@ -155,8 +155,8 @@ function tick(time: number): void {
 }
 
 function play(): void {
-  playStopButton.innerText = stopLabel;
-  playStopButton.setAttribute('aria-label', 'stop');
+  // playStopButton.innerText = stopLabel;
+  // playStopButton.setAttribute('aria-label', 'stop');
 
   frameId = rAF((time: number) => {
     firstTime = time;
@@ -168,8 +168,8 @@ function play(): void {
 }
 
 function stop(): void {
-  playStopButton.innerText = playLabel;
-  playStopButton.setAttribute('aria-label', 'play');
+  // playStopButton.innerText = playLabel;
+  // playStopButton.setAttribute('aria-label', 'play');
 
   cAF(frameId);
   frameId = -1;
@@ -187,5 +187,5 @@ function toggle(): void {
   frameId === -1 ? play() : stop();
 }
 
-playStopButton.addEventListener('click', toggle);
-goto(0);
+// playStopButton.addEventListener('click', toggle);
+play();

--- a/source/style.scss
+++ b/source/style.scss
@@ -1,6 +1,7 @@
 html,
 body,
-main {
+main,
+canvas {
   width: 100%;
   height: 100%;
 }
@@ -19,7 +20,5 @@ main {
 
 canvas {
   background: black;
-  width: 800px;
-  height: 450px;
   image-rendering: pixelated;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "module": "es2015",
     "moduleResolution": "node",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
   version "22.1.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.1.1.tgz#231d7c60ed130200af9e96c82469ed25b59a7ea2"
 
+"@types/seedrandom@^2.4.27":
+  version "2.4.27"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.27.tgz#9db563937dd86915f69092bc43259d2f48578e41"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -4760,6 +4764,10 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seedrandom@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"


### PR DESCRIPTION
Adds `seedrandom` for predictable pseudo-random number generation. Removes controls from the simulator, makes it full screen and auto-plays it on load. Adds a deployment step to publish to `gh-pages`.